### PR TITLE
Minimal version of proc-macro-hack which doesn't require 'syn'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,6 @@ jobs:
       run: cargo test
     - name: Test example
       run: cd examples/string-enum && cargo run --example simple
+    - name: Test absolution-hack
+      run: cd absolution-hack/example && cargo run
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target
 Cargo.lock

--- a/absolution-hack/Cargo.toml
+++ b/absolution-hack/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "absolution-hack"
+version = "0.1.0"
+authors = ["Nika Layzell <nika@thelayzells.com>"]
+edition = "2018"
+description = "Miminal version of 'proc-macro-hack' which doesn't require 'syn'"
+license = "MIT/Apache-2.0"
+repository = "https://github.com/Manishearth/absolution"
+categories = ["development-tools::procedural-macro-helpers"]
+
+[dependencies]

--- a/absolution-hack/demo-hack-impl/Cargo.toml
+++ b/absolution-hack/demo-hack-impl/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "demo-hack-impl"
+version = "0.1.0"
+authors = ["Nika Layzell <nika@thelayzells.com>"]
+edition = "2018"
+
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+absolution-hack = { path = ".." }
+absolution = { path = "../.." }
+quote = "1.0"

--- a/absolution-hack/demo-hack-impl/src/lib.rs
+++ b/absolution-hack/demo-hack-impl/src/lib.rs
@@ -1,0 +1,11 @@
+use absolution::TokenStream;
+use quote::quote;
+
+// Declare the helper code in the proc macro, wrapping our `add_one_impl`
+// function into a `__add_one_impl` custom derive.
+absolution_hack::define_absolution_hack!(__add_one_impl => add_one_impl);
+
+fn add_one_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input: TokenStream = input.into();
+    quote!(1 + (#input)).into()
+}

--- a/absolution-hack/demo-hack/Cargo.toml
+++ b/absolution-hack/demo-hack/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "demo-hack"
+version = "0.1.0"
+authors = ["Nika Layzell <nika@thelayzells.com>"]
+edition = "2018"
+
+publish = false
+
+[dependencies]
+absolution-hack = { path = ".." }
+demo-hack-impl = { path = "../demo-hack-impl" }

--- a/absolution-hack/demo-hack/src/lib.rs
+++ b/absolution-hack/demo-hack/src/lib.rs
@@ -1,0 +1,4 @@
+absolution_hack::declare_absolution_hack! {
+    /// This macro adds one to it's input value in a very round-about way.
+    pub use demo_hack_impl::__add_one_impl as add_one;
+}

--- a/absolution-hack/example/Cargo.toml
+++ b/absolution-hack/example/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example"
+version = "0.1.0"
+authors = ["Nika Layzell <nika@thelayzells.com>"]
+edition = "2018"
+
+publish = false
+
+[dependencies]
+demo-hack = { path = "../demo-hack" }

--- a/absolution-hack/example/src/main.rs
+++ b/absolution-hack/example/src/main.rs
@@ -1,0 +1,7 @@
+use demo_hack::add_one;
+
+fn main() {
+    let two = 2;
+    let nine = add_one!(two) + add_one!(2 + 3);
+    println!("nine = {}", nine);
+}

--- a/absolution-hack/src/lib.rs
+++ b/absolution-hack/src/lib.rs
@@ -1,0 +1,113 @@
+//! Helper macros for declaring and defining a `proc-macro-hack`-like macro
+//! without depending on `syn`.
+//!
+//! Unlike `proc-macro-hack`, this crate makes no effort to provide advanced
+//! features, like nested macro support, or customized hygiene. If you need
+//! these advanced features, use the `proc-macro-hack` crate.
+
+/// Used in the wrapper crate.
+#[macro_export]
+macro_rules! declare_absolution_hack {
+    (
+        $(#[$m:meta])*
+        pub use $krate:ident :: $real_name:ident as $name:ident;
+    ) => {
+        $crate::declare_hack_internal!([$] [$(#[$m])*] $krate $real_name $name);
+    };
+}
+
+// Not public API.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! declare_hack_internal {
+    ([$dlr:tt] [$($m:tt)*] $krate:ident $real_name:ident $name:ident) => {
+        #[doc(hidden)]
+        pub use $krate :: $real_name;
+
+        $($m)*
+        #[macro_export]
+        macro_rules! $name {
+            // ($($proc_macro:tt)*) =>
+            ($dlr($dlr proc_macro:tt)*) => {{
+                // Call the custom derive from within an expression block.
+                #[derive($dlr crate :: $real_name)]
+                enum AbsolutionHack {
+                    Value = (stringify! { $dlr($dlr proc_macro)* }, 0).1,
+                }
+                // Invoke the generated `macro_rules!` macro
+                absolution_hack_call!()
+            }};
+        }
+    };
+}
+
+/// Used in the wrappee crate.
+#[macro_export]
+macro_rules! define_absolution_hack {
+    ($name:ident => $func:ident) => {
+        // Declare our method which consumes the `TokenStream`.
+        //
+        // The logic is declared entirely within the target crate, despite it
+        // being possible to declare a helper method which would simplify
+        // things, in order to avoid having this crate directly depend on
+        // `proc_macro`, as it is also depended on by the declaration crate.
+        #[proc_macro_derive($name)]
+        pub fn $name(input: ::proc_macro::TokenStream) -> ::proc_macro::TokenStream {
+            use ::proc_macro::{
+                Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree,
+            };
+            use ::std::iter::FromIterator;
+
+            let mut iter = input.into_iter();
+            iter.next().unwrap(); // `enum`
+            iter.next().unwrap(); // `AbsolutionHack`
+
+            // Enter { ... }
+            let mut iter = match iter.next().unwrap() {
+                TokenTree::Group(group) => group.stream().into_iter(),
+                _ => unimplemented!(),
+            };
+            iter.next().unwrap(); // `Value`
+            iter.next().unwrap(); // `=`
+
+            // Enter ( ... )
+            let mut iter = match iter.next().unwrap() {
+                TokenTree::Group(group) => group.stream().into_iter(),
+                _ => unimplemented!(),
+            };
+            iter.next().unwrap(); // `stringify`
+            iter.next().unwrap(); // `!`
+
+            // Get stream from { ... }
+            let input = match iter.next().unwrap() {
+                TokenTree::Group(group) => group.stream(),
+                _ => unimplemented!(),
+            };
+
+            // Invoke the real macro implementation.
+            let output: TokenStream = $func(input.clone());
+
+            // Wrap in a dummy macro invocation:
+            // macro_rules! absolution_hack_call {
+            //     () => { #output }
+            // }
+            TokenStream::from_iter(vec![
+                TokenTree::Ident(Ident::new("macro_rules", Span::call_site())),
+                TokenTree::Punct(Punct::new('!', Spacing::Alone)),
+                TokenTree::Ident(Ident::new(
+                    "absolution_hack_call",
+                    ::proc_macro::Span::call_site(),
+                )),
+                TokenTree::Group(Group::new(
+                    Delimiter::Brace,
+                    TokenStream::from_iter(vec![
+                        TokenTree::Group(Group::new(Delimiter::Parenthesis, TokenStream::new())),
+                        TokenTree::Punct(Punct::new('=', Spacing::Joint)),
+                        TokenTree::Punct(Punct::new('>', Spacing::Alone)),
+                        TokenTree::Group(Group::new(Delimiter::Brace, output)),
+                    ]),
+                )),
+            ])
+        }
+    };
+}


### PR DESCRIPTION
This initial version is still very minimal, and I've written no competent usage documentation yet.

See the example in the `absolution-hack` subdirectory for usage information.